### PR TITLE
Fix error on decoding byte string; show usage message

### DIFF
--- a/json_tool.py
+++ b/json_tool.py
@@ -18,7 +18,7 @@ req.add_header('Content-Type', 'application/json')
 
 try:
     resp =  urllib.request.urlopen(req)
-    parsed = json.loads(resp.read())
+    parsed = json.loads(resp.read().decode('utf8'))
     print(json.dumps(parsed, indent=4, sort_keys=True))
 
 except urllib.error.HTTPError as err:

--- a/tip-tester.sh
+++ b/tip-tester.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ $# -ne 1 ]; then
+    echo usage: ./tip-tester.sh http://host:port
+    exit 1
+fi
 SERVER=$1
 
 echo "testing ${SERVER}"

--- a/tip-tester.sh
+++ b/tip-tester.sh
@@ -7,7 +7,7 @@ echo "testing ${SERVER}"
 #rm -rf ./responses/*
 
 echo "config"
-python3 json_tool.py ${SERVER} /api/config > ./responses/config_response.json
+python3 json_tool.py ${SERVER} /api/config || exit 1 > ./responses/config_response.json
 diff ./expected/config_expect.json ./responses/config_response.json
 
 for FILENAME in $(ls ./requests)


### PR DESCRIPTION
These patches

* Fix an error I had running the script with Python 3.5.3
* Exit early from tip-tester.sh if there is an exception in the Python script (but not if there is an HTTPError)
* Print out a usage message if you run tip-tester.sh without an argument

I also noticed that itinerary7.json is not valid json. (See #1) I'm not sure if that's intentional. If it is intentional, I suggest that you return an error 400 in that case, not an error 500.

Our implementation agrees with yours except for nearest neighbor, which I think we implemented differently.